### PR TITLE
Support for LangChain 1.0

### DIFF
--- a/bot_ui.py
+++ b/bot_ui.py
@@ -15,7 +15,7 @@ from langchain_core.runnables import (
 )
 from langchain_core.output_parsers import StrOutputParser
 from langchain_couchbase.chat_message_histories import CouchbaseChatMessageHistory
-from langchain.chains.combine_documents import create_stuff_documents_chain
+from langchain_classic.chains.combine_documents import create_stuff_documents_chain
 from langchain_core.messages import AIMessage, HumanMessage
 
 import streamlit as st

--- a/ingest_docs.py
+++ b/ingest_docs.py
@@ -4,7 +4,7 @@ import json
 from tqdm import tqdm
 from dotenv import load_dotenv
 from langchain_openai import OpenAIEmbeddings
-from langchain.text_splitter import (
+from langchain_text_splitters import (
     RecursiveCharacterTextSplitter,
 )
 from langchain_couchbase.vectorstores import CouchbaseSearchVectorStore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.14.2
-langchain-couchbase==1.0.0
 langchain-classic==1.0.0
+langchain-couchbase==1.0.0
 langchain-community==0.3.31
 langchain-openai==1.1.0
 langsmith==0.4.39

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 beautifulsoup4==4.14.2
 langchain-couchbase==1.0.0
+langchain-classic==1.0.0
 langchain-community==0.3.31
 langchain-openai==1.1.0
 langsmith==0.4.39


### PR DESCRIPTION
Refactor imports in bot_ui.py and ingest_docs.py to use updated module paths

- Changed import path for create_stuff_documents_chain in bot_ui.py from langchain.chains.combine_documents to langchain_classic.chains.combine_documents.
- Updated import path for RecursiveCharacterTextSplitter in ingest_docs.py from langchain.text_splitter to langchain_text_splitters.
- Added langchain-classic==1.0.0 to requirements.txt.